### PR TITLE
End game, Hedge Case4 and Price Distribution implementation

### DIFF
--- a/src/UrbeArenaGladiators.sol
+++ b/src/UrbeArenaGladiators.sol
@@ -331,9 +331,9 @@ contract UrbeArenaGladiators is ERC721Enumerable, Ownable {
 
     //utility function to register a new share
     function _registerShare(uint256 id) internal {
+        require(day >= topLow);
         require(totalDeaths <= totalSupply() - 2);
         require(id!=999);
-        require(day >= topLow);
         shares.push(id);
     }
 


### PR DESCRIPTION
**The code that is the subject of the PR is code that is probably not optimized to the best and not yet tested.**

The PR is used to implement 3 points stated in the Urbe Arena notion ([link](https://www.notion.so/Urbe-Arena-NFT-Game-aa7b4f1c413e4ba8937a88d93df979cc#69b4d1c4cf894bb4850d272a9b8b0df6)) namely:
- end game (define the final winner)
- Implement Hedge case 4 (win two gladiators at the end)
- Price distribution 

In particular, keep the following in mind before considering the PR code:
- because of the way Gladiators are handled we can always know how many gladiators died (`totalDeaths`), how many gladiators are alive (`totalSupply` - `totalDeaths`) , which gladiator died on a specific day (mapping `deathByDays`) however there is no direct way to know the id's of the living gladiators
- since we do not know which gladiators are alive we cannot directly know who is the winner(s) (in the case of hedge case4)
- the prize should be distributed 50% to the winner or winners in the case of hedge case4 (in this case they each take 25% of the treasury). The other top x gladiators should receive a proportional amount relative to when they died. However, we do not know a priori which gladiators will be in the top. The parameter we can use for a time classification is the mapping `deathByDays`


Summary of changes made:

1. in the struct Gladiator `isDead` was replaced with `isAlive`. isDead used to be initialized to false while isAlive is initialized to true in the mint and then changed to false when the gladiator dies. This is because passing a token id that did not exist returned isDead false and therefore could not be used correctly in checks/require. Checks that used isDead have been replaced with isAlive 

2.  In the `closeDailyFight`, a `_registerShare`(`deathGladiatorId`) call was inserted that pushes the gladiator ids if they died after a certain day (`dayTop`) into an array called shares. These ids are the gladiators that fall in the top x. The top is defined by all gladiators who died after dayTop

3. implemented the call `finalizeGameAndSplitTreasuryWinner`( , , ) which can be called by anyone (the caller receives an executor reward) that does the following:
     - sends the reward to the winner(s) (in hedge case4)
     - sends the executor reward to the person who called the function
     - issues the Winner event with the winners  
     - assigns a share amount to the ids previously saved in the shares array. the share amount is incremental with respect to the position in the shares array i.e. with respect to the order of death after a certain day (dayTop)

4. implemented the `widthdraw`(`id`) call which allows gladiators who have re-entered the top to make the claim of their prize proportional to the amount of shares previously assigned

Notes:
- defining the top according to whether they died after `dayTop` could be a problem because we cannot define a priori how many gladiators will re-enter the top. However, it introduces an interesting game mechanic whereby gladiators can agree not to stick and die in order to re-enter the top and take the prize. But then if a gladiator betrays the agreement and attacks someone he can easily kill him
- For the distribution of prizes using shares, the splitter of Open Zeppelin was taken as a reference. Here you can find a simulation of price distribution considering 20 gladiators in the top out of 100 total gladiators -> [link](https://docs.google.com/spreadsheets/d/14g7wyr6Ng-akTrJMIFPbEtdvD8a8p7O5CfgnBZVBm-0/edit#gid=0)
- handling the shares which first goes through the shares array populated in closeDailyFight and then the amounts are allocated in `finalizeGameAndSplitTreasuryWinner`( , , ) is definitely not efficient
- data to pass to init to populate variables such as executorRewardPercentage, dayTop etc. are currently missing


